### PR TITLE
Save on debounce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3885,6 +3885,11 @@
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
       "dev": true
     },
+    "debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
+    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
    },
    "dependencies": {
       "core-js": "^2.6.5",
+      "debounce": "^1.2.0",
       "marked": "^1.2.0",
       "moment": "^2.29.0",
       "vue": "^2.6.10"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <script>
 import moment from 'moment';
+import debounce from 'debounce';
 import Note from '@/components/Note.vue';
 import NoteEdit from '@/views/NoteEdit.vue';
 
@@ -51,8 +52,6 @@ export default {
       } else {
          localStorage.setItem('simple-notes', JSON.stringify([]));
       }
-
-      this.autoSave();
    },
 
    /*
@@ -65,17 +64,9 @@ export default {
 
    // Methods: It allows to declare methods that could be used in our project
    methods: {
-      autoSave() {
-         this.interval = setInterval(() => {
-            if (!this.saved) {
-               localStorage.setItem('simple-notes', JSON.stringify(this.notes));
-               this.saved = true;
-            }
-         }, 1000 * 5); // save every 5 seconds
-      },
-
       newNote() {
          this.notes.unshift(new NoteClass());
+         this.save();
       },
 
       selectNote(index) {
@@ -86,7 +77,19 @@ export default {
       editNote(key, e) {
          this.notes[this.selected][key] = e.target.value;
          this.saved = false;
+         this.debounceSave();
       },
+
+      save() {
+         localStorage.setItem('simple-notes', JSON.stringify(this.notes));
+         this.saved = true;
+      },
+
+      debounceSave: debounce(function () {
+         if (!this.saved) {
+            this.save();
+         }
+      }, 3 * 1000),
 
       deleteNote(e, index) {
          e.stopPropagation();
@@ -95,6 +98,7 @@ export default {
             const newNotes = [...this.notes];
             newNotes.splice(index, 1);
             this.notes = newNotes;
+            this.save();
          }
       },
    },


### PR DESCRIPTION
Creating / Deleting a note saves immediately using `save()`;

Editing a note or its title saves using a debouncer with a 3 seconds delay

Fixes #20 
